### PR TITLE
optimize(projects): remove deprecated disableCache from iconify setup

### DIFF
--- a/src/plugins/iconify.ts
+++ b/src/plugins/iconify.ts
@@ -1,4 +1,4 @@
-import { addAPIProvider, disableCache } from '@iconify/react';
+import { addAPIProvider } from '@iconify/react';
 
 /** Setup the iconify offline */
 export function setupIconifyOffline() {
@@ -6,7 +6,5 @@ export function setupIconifyOffline() {
 
   if (VITE_ICONIFY_URL) {
     addAPIProvider('', { resources: [VITE_ICONIFY_URL] });
-
-    disableCache('all');
   }
 }


### PR DESCRIPTION
Remove disableCache function call as it's deprecated in @iconify/react

https://iconify.design/docs/icon-components/react/disable-cache.html#iconify-for-react-function-disablecache