### PR TITLE
fix(projects): 清除退出时的redirect参数和tab标签残留数据

### DIFF
--- a/src/features/auth/auth.ts
+++ b/src/features/auth/auth.ts
@@ -3,10 +3,9 @@ import { useLoading } from '@sa/hooks';
 import { globalConfig } from '@/config';
 import { getIsLogin, selectUserInfo } from '@/features/auth/authStore';
 import { usePreviousRoute, useRouter } from '@/features/router';
+import { useCacheTabs, useClearTabs } from '@/features/tab/tabHooks';
 import { fetchGetUserInfo, fetchLogin } from '@/service/api';
 import { localStg } from '@/utils/storage';
-
-import { useCacheTabs } from '../tab/tabHooks';
 
 import { resetAuth as resetAuthAction, setToken, setUserInfo } from './authStore';
 import { clearAuthStorage } from './shared';
@@ -117,4 +116,38 @@ export function useResetAuth() {
   }
 
   return resetAuth;
+}
+
+// 新增：退出登录
+export function useLogout() {
+  const dispatch = useAppDispatch();
+
+  const clearTabs = useClearTabs();
+
+  const { navigate, resetRoutes } = useRouter();
+
+  /**
+   * 用户 用户退出登录处理函数
+   *
+   * 功能：该函数负责处理用户的退出登录操作，包括清除本地存储中的认证信息、重置状态管理中的认证状态、清空标签页数据、重置路由权限配置，并最终导航到登录页面。
+   */
+  function toLogout() {
+    // 清除本地存储中的认证信息
+    clearAuthStorage();
+
+    // 触发状态管理中的认证信息重置动作
+    dispatch(resetAuthAction());
+
+    // 清空标签页（tab）存储的页面列表数据，避免后续用户看到残留的上一用户标签
+    clearTabs();
+
+    // 重置路由权限配置，确保新登录用户只能正确的路由访问权限
+    resetRoutes();
+
+    // 跳转到登录页，使用replace模式替换当前历史记录，避免用户通过回退按钮返回已退出的页面
+    // 此处跳转默认会清除原URL中的redirect参数（因未携带参数），使登录页恢复纯净状态
+    navigate('/login', { replace: true });
+  }
+
+  return toLogout;
 }

--- a/src/features/tab/tabHooks.ts
+++ b/src/features/tab/tabHooks.ts
@@ -4,6 +4,7 @@ import { useRoute, useRouter } from '@/features/router';
 import {
   addTab,
   changeTabLabel,
+  clearTabData,
   selectActiveTabId,
   selectTabs,
   setActiveFirstLevelMenuKey,
@@ -241,6 +242,16 @@ export function initTab(cache: boolean, updateTabs: (tabs: App.Global.Tab[]) => 
   }
 
   return [];
+}
+
+// 新增：清空所有标签页相关数据
+export function useClearTabs() {
+  const dispatch = useAppDispatch();
+  function clearTabs() {
+    localStg.remove('globalTabs');
+    dispatch(clearTabData());
+  }
+  return clearTabs;
 }
 
 export function useCacheTabs() {

--- a/src/features/tab/tabStore.ts
+++ b/src/features/tab/tabStore.ts
@@ -41,6 +41,10 @@ export const tabSlice = createSlice({
         state.tabs[index].i18nKey = state.tabs[index].oldLabel;
       }
     },
+    // 新增：清空所有标签页相关数据（重置为初始状态）
+    clearTabData: () => {
+      return initialState;
+    },
     setActiveFirstLevelMenuKey: (state, action: PayloadAction<string>) => {
       state.activeFirstLevelMenuKey = action.payload;
     },
@@ -63,7 +67,7 @@ export const tabSlice = createSlice({
   }
 });
 
-export const { addTab, changeTabLabel, setActiveFirstLevelMenuKey, setActiveTabId, setTabs, updateTab } =
+export const { addTab, changeTabLabel, clearTabData, setActiveFirstLevelMenuKey, setActiveTabId, setTabs, updateTab } =
   tabSlice.actions;
 
 export const { selectActiveFirstLevelMenuKey, selectActiveTabId, selectTabs } = tabSlice.selectors;

--- a/src/layouts/modules/global-header/components/UserAvatar.tsx
+++ b/src/layouts/modules/global-header/components/UserAvatar.tsx
@@ -1,5 +1,6 @@
 import type { MenuProps } from 'antd';
 
+import { useLogout } from '@/features/auth';
 import { selectToken, selectUserInfo } from '@/features/auth/authStore';
 import { useRouter } from '@/features/router';
 
@@ -12,13 +13,15 @@ const UserAvatar = memo(() => {
 
   const { navigate } = useRouter();
 
+  // 处理用户退出
+  const toLogout = useLogout();
   function logout() {
     window?.$modal?.confirm({
       cancelText: t('common.cancel'),
       content: t('common.logoutConfirm'),
       okText: t('common.confirm'),
       onOk: () => {
-        navigate('/login-out');
+        toLogout();
       },
       title: t('common.tip')
     });


### PR DESCRIPTION
Fixes #80 

#### 1. 修复的问题

同一设备切换角色登录时，因退出登录后未清理两部分数据导致权限异常：

- 登录页 URL 残留`redirect=/function/super-page`参数，非 super 角色登录后被强制跳转至无权限页面，触发 403 错误；
- tab 标签栏残留上一用户的页面列表，当前用户可见但部分页面无权限访问。

#### 2. 核心修改逻辑

本次修复围绕“退出登录时彻底清除残留数据”展开，核心修改涉及4个文件，具体逻辑如下：

1. **auth.ts（核心退出逻辑）**  
   新增`toLogout`函数，整合完整退出流程：  
   - 调用`clearAuthStorage()`清除本地存储的认证信息（如token）；  
   - 通过`dispatch(resetAuthAction())`重置全局认证状态（用户信息、角色权限等）；  
   - 新增`clearTabs()`调用，清空标签页数据（关联`tabHooks.ts`的实现）；  
   - 新增`resetRoutes()`重置路由权限配置，避免权限残留；  
   - 最终通过`navigate('/login', { replace: true })`跳转至纯净登录页（不携带`redirect`参数，自动清除URL中原有参数）。

2. **tabHooks.ts（标签页清理工具）**  
   新增`useClearTabs`自定义钩子，提供`clearTabs`方法：  
   - 调用`localStg.remove('globalTabs')`删除本地存储的标签页数据；  
   - 通过`dispatch(clearTabData())`触发状态管理中标签页数据的清空。

3. **tabStore.ts（标签页状态管理）**  
   新增`clearTabData` action，将标签页状态重置为`initialState`（初始空状态），配合`tabHooks.ts`完成全局标签数据清理。

4. **UserAvatar.tsx（退出入口）**  
   修改退出登录触发逻辑：  
   - 引入`useLogout`获取`toLogout`方法；  
   - 在确认退出的`onOk`回调中，使用`toLogout()`替代原`navigate('/login-out')`，确保执行完整的清理流程。

通过以上修改，实现了“退出即彻底重置”的效果，从根源上避免`redirect`参数和标签页数据残留。

#### 3. 测试验证

已在本地环境完成多轮测试，确认修复效果：

- 以 super 角色登录并访问`/function/super-page`，执行退出后，登录页 URL 无`redirect`参数；
- 使用 Admin/User 角色登录，未强制跳转至`/function/super-page`，自动进入对应角色的默认首页；
- 登录后 tab 标签栏无任何残留数据，仅显示当前角色可访问的初始标签；
- 全流程无 403 权限错误，且未引入新的页面异常或功能冲突。