### PR TITLE
feat(project): UI设置中tab标签样式添加滑块风格

### DIFF
--- a/packages/materials/src/libs/page-tab/SliderTab.tsx
+++ b/packages/materials/src/libs/page-tab/SliderTab.tsx
@@ -1,0 +1,44 @@
+import classNames from 'clsx';
+
+import type { ButtonTabProps } from '../../types';
+
+import { useTap } from './hook';
+import styles from './index.module.css';
+
+const SliderTab = ({
+  active,
+  children,
+  className,
+  darkMode,
+  onClick,
+  prefix,
+  style,
+  suffix,
+  ...rest
+}: ButtonTabProps) => {
+  const tap = useTap(onClick);
+
+  return (
+    <div
+      {...rest}
+      {...tap}
+      style={{ ...style }}
+      className={classNames(
+        ':soy: relative inline-flex cursor-pointer items-center justify-center gap-6px whitespace-nowrap px-12px py-4px',
+        [
+          styles['slider-tab'],
+          { [styles['slider-tab_dark']]: darkMode },
+          { [styles['slider-tab_active']]: active },
+          { [styles['slider-tab_active_dark']]: active && darkMode },
+          className
+        ]
+      )}
+      onClick={onClick}
+    >
+      {prefix}
+      {children}
+      {suffix}
+    </div>
+  );
+};
+export default SliderTab;

--- a/packages/materials/src/libs/page-tab/index.module.css
+++ b/packages/materials/src/libs/page-tab/index.module.css
@@ -95,3 +95,26 @@
 .chrome-tab_dark .chrome-tab-divider {
   background-color: rgba(255, 255, 255, 0.9);
 }
+.slider-tab {
+  background-color: transparent;
+  height: 100%;
+  border-bottom: 2px solid transparent;
+}
+
+.slider-tab_dark {
+  background-color: transparent;
+}
+
+.slider-tab:hover {
+  color: var(--soy-primary-color);
+}
+
+.slider-tab_active {
+  color: var(--soy-primary-color);
+  background-color: var(--soy-primary-color-opacity1);
+  border-bottom-color: var(--soy-primary-color);
+}
+
+.slider-tab_active_dark {
+  background-color: var(--soy-primary-color-opacity2);
+}

--- a/packages/materials/src/libs/page-tab/index.module.css.d.ts
+++ b/packages/materials/src/libs/page-tab/index.module.css.d.ts
@@ -9,6 +9,10 @@ declare const styles: {
   readonly 'chrome-tab_active_dark': string;
   readonly 'chrome-tab_dark': string;
   readonly 'chrome-tab-divider': string;
+  readonly 'slider-tab': string;
+  readonly 'slider-tab_active': string;
+  readonly 'slider-tab_active_dark': string;
+  readonly 'slider-tab_dark': string;
   readonly 'svg-close': string;
 };
 export default styles;

--- a/packages/materials/src/libs/page-tab/index.tsx
+++ b/packages/materials/src/libs/page-tab/index.tsx
@@ -6,6 +6,7 @@ import type { ButtonTabProps } from '../../types';
 
 import ButtonTab from './ButtonTab';
 import ChromeTab from './ChromeTab';
+import SliderTab from './SliderTab';
 import SvgClose from './SvgClose';
 import styles from './index.module.css';
 import { ACTIVE_COLOR, createTabCssVars } from './shared';
@@ -24,6 +25,7 @@ const PageTab: FC<PageTabProps> = ({
   handleClose,
   mode = 'chrome',
   prefix,
+  sliderClass,
   style,
   suffix,
   ...rest
@@ -38,6 +40,10 @@ const PageTab: FC<PageTabProps> = ({
     chrome: {
       class: chromeClass,
       component: ChromeTab
+    },
+    slider: {
+      class: sliderClass,
+      component: SliderTab
     }
   };
 

--- a/packages/materials/src/types/index.ts
+++ b/packages/materials/src/types/index.ts
@@ -262,7 +262,7 @@ export type LayoutCssVars = {
  *
  * @default chrome
  */
-export type PageTabMode = 'button' | 'chrome';
+export type PageTabMode = 'button' | 'chrome' | 'slider';
 export type ButtonTabProps = PageTabProps &
   Omit<React.ComponentProps<'div'>, 'className' | 'onClick' | 'prefix' | 'style'>;
 export interface PageTabProps {
@@ -301,6 +301,8 @@ export interface PageTabProps {
   mode?: PageTabMode;
   onClick: () => void;
   prefix: React.ReactNode;
+  /** The class of the slider tab */
+  sliderClass?: string;
   style?: React.CSSProperties;
   suffix?: React.ReactNode;
 }

--- a/src/constants/app.ts
+++ b/src/constants/app.ts
@@ -29,7 +29,8 @@ export const themeScrollModeOptions = transformRecordToOption(themeScrollModeRec
 
 export const themeTabModeRecord: Record<UnionKey.ThemeTabMode, App.I18n.I18nKey> = {
   button: 'theme.tab.mode.button',
-  chrome: 'theme.tab.mode.chrome'
+  chrome: 'theme.tab.mode.chrome',
+  slider: 'theme.tab.mode.slider'
 };
 
 export const themeTabModeOptions = transformRecordToOption(themeTabModeRecord);

--- a/src/features/tab/GlobalTab.tsx
+++ b/src/features/tab/GlobalTab.tsx
@@ -86,7 +86,10 @@ const GlobalTab = () => {
                 mode={themeSettings.tab.mode}
                 tabId={item.id}
               >
-                <div id={item.id}>
+                <div
+                  className={themeSettings.tab.mode === 'slider' ? 'h-full' : undefined}
+                  id={item.id}
+                >
                   <PageTab
                     active={item.id === activeTabId}
                     activeColor={themeSettings.themeColor}

--- a/src/locales/langs/en-us/theme.ts
+++ b/src/locales/langs/en-us/theme.ts
@@ -66,6 +66,7 @@ const theme: App.I18n.Schema['translation']['theme'] = {
     mode: {
       button: 'Button',
       chrome: 'Chrome',
+      slider: 'Slider',
       title: 'Tab Mode'
     },
     visible: 'Tab Visible'

--- a/src/locales/langs/zh-cn/theme.ts
+++ b/src/locales/langs/zh-cn/theme.ts
@@ -66,6 +66,7 @@ const theme: App.I18n.Schema['translation']['theme'] = {
     mode: {
       button: '按钮风格',
       chrome: '谷歌风格',
+      slider: '滑块风格',
       title: '标签栏风格'
     },
     visible: '显示标签栏'


### PR DESCRIPTION
- 参考soybean Vue版本，为tab标签添加“滑块风格”
<img width="498" height="248" alt="image" src="https://github.com/user-attachments/assets/96477447-5d81-4a36-9002-958e1f1e89ed" />
<img width="1025" height="272" alt="image" src="https://github.com/user-attachments/assets/41644ac9-3f59-48d6-87e1-50c0d610f26d" />
